### PR TITLE
Fixed bugs with scales display

### DIFF
--- a/src/display/displayTemplateScale.h
+++ b/src/display/displayTemplateScale.h
@@ -63,23 +63,34 @@ void printScreen() {
      * If scale has an error show fault on the display otherwise show current reading of the scale
      * if brew is running show current brew time and current brew weight
      * if brewControl is enabled and time or weight target is set show targets
-     * if brewControl is enabled show flush time during manualFlush
+     * show flush time during manualFlush
      * if FEATURE_PRESSURESENSOR is enabled show current pressure during brew
      * if brew is finished show brew values for postBrewTimerDuration
      */
 
     // Show current weight if scale has no error
-    u8g2.setCursor(32, 26);
+    u8g2.setCursor(32, 36);
     u8g2.print(langstring_weight);
-    u8g2.setCursor(82, 26);
+    u8g2.setCursor(82, 36);
     if (scaleFailure) {
         u8g2.print("fault");
     }
-    else if (machineState == kManualFlush) {
-        // Shown flush time
-        u8g2.setDrawColor(0);
-        u8g2.drawBox(32, 26, 100, 40);
-        u8g2.setDrawColor(1);
+    else {
+        if (shouldDisplayBrewTimer()) {
+            u8g2.print(weightBrewed, 0);
+            if(featureBrewControl && weightSetpoint > 0) {
+                u8g2.print("/");
+                u8g2.print(weightSetpoint, 0);
+            }
+        }
+        else {
+            u8g2.print(currWeight, 0);
+        }
+        u8g2.print(" g");
+    }
+
+    if (machineState == kManualFlush) {
+    // Shown flush time
         u8g2.setCursor(32, 26);
         u8g2.print(langstring_manual_flush);
         u8g2.setCursor(82, 26);
@@ -87,51 +98,17 @@ void printScreen() {
         u8g2.print(" s");
     }
     else if (shouldDisplayBrewTimer()) {
-        // Shown brew time and weight
-        if (featureBrewControl) {
-            // weight
-            u8g2.setCursor(32, 36);
-            u8g2.print(langstring_weight);
-            u8g2.setCursor(82, 36);
-            u8g2.print(weightBrewed, 0);
+        // time
+        u8g2.setCursor(32, 26);
+        u8g2.print(langstring_brew);
+        u8g2.setCursor(82, 26);
+        u8g2.print(timeBrewed / 1000, 0);
 
-            if (weightSetpoint > 0) {
-                u8g2.print("/");
-                u8g2.print(weightSetpoint, 0);
-            }
-            u8g2.print(" g");
-
-            // time
-            u8g2.setCursor(32, 26);
-            u8g2.print(langstring_brew);
-            u8g2.setCursor(82, 26);
-            u8g2.print(timeBrewed / 1000, 0);
-
-            if (brewTime > 0) {
-                u8g2.print("/");
-                u8g2.print(totalBrewTime / 1000, 0);
-            }
-            u8g2.print(" s");
+        if (featureBrewControl && brewTime > 0) {
+            u8g2.print("/");
+            u8g2.print(totalBrewTime / 1000, 0);
         }
-        else {
-            // Brew Timer with optocoupler
-            // weight
-            u8g2.setCursor(32, 36);
-            u8g2.print(langstring_weight);
-            u8g2.setCursor(82, 36);
-            u8g2.print(weightBrewed, 0);
-            u8g2.print(" g");
-            // time
-            u8g2.setCursor(32, 26);
-            u8g2.print(langstring_brew);
-            u8g2.setCursor(82, 26);
-            u8g2.print(timeBrewed / 1000, 0);
-            u8g2.print(" s");
-        }
-    }
-    else {
-        u8g2.print(currWeight, 0);
-        u8g2.print(" g");
+        u8g2.print(" s");
     }
 
 #if (FEATURE_PRESSURESENSOR == 1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -736,10 +736,6 @@ void handleMachineState() {
                 machineState = kPidNormal;
             }
 
-            if (!waterTankFull) {
-                machineState = kWaterTankEmpty;
-            }
-
             if (tempSensor->hasError()) {
                 machineState = kSensorError;
             }

--- a/src/scaleHandler.h
+++ b/src/scaleHandler.h
@@ -138,6 +138,7 @@ void initScale() {
 
     if (LoadCell.getTareTimeoutFlag() || LoadCell.getSignalTimeoutFlag()) {
         LOG(ERROR, "Timeout, check MCU>HX711 wiring for scale");
+        u8g2.clearBuffer();
         u8g2.drawStr(0, 32, "failed!");
         u8g2.drawStr(0, 42, "Scale not working..."); // scale timeout will most likely trigger after OTA update, but will still work after boot
         u8g2.sendBuffer();
@@ -149,6 +150,7 @@ void initScale() {
 #if SCALE_TYPE == 0
     if (LoadCell2.getTareTimeoutFlag() || LoadCell2.getSignalTimeoutFlag()) {
         LOG(ERROR, "Timeout, check MCU>HX711 wiring for scale 2");
+        u8g2.clearBuffer();
         u8g2.drawStr(0, 32, "failed!");
         u8g2.drawStr(0, 42, "Scale not working..."); // scale timeout will most likely trigger after OTA update, but will still work after boot
         u8g2.sendBuffer();


### PR DESCRIPTION
DisplayTemplateScale
weight always shown 3rd down
brew or flush shown second down
time and weight setpoints shown if brewcontrol is enabled and values >0

ScaleHandler
added clearbuffer to stop it overwriting boot screen

Main
removed check for waterempty in PIDDisabled as it was toggling between the two and PIDDisabled screen has water icon in top right
